### PR TITLE
Fix PWM slice typo in ultrasonic chapter (4.3)

### DIFF
--- a/src/ultrasonic/code.md
+++ b/src/ultrasonic/code.md
@@ -27,7 +27,7 @@ You should understand this code by now. If not, please complete the Blink LED se
 Quick recap: Here, we're configuring the PWM for the LED, which allows us to control the brightness by adjusting the duty cycle.
 
 ```rust
-let pwm = &mut pwm_slices.pwm6;  // Access PWM slice 6
+let pwm = &mut pwm_slices.pwm1;  // Access PWM slice 1
 pwm.set_ph_correct();            // Set phase-correct mode for smoother transitions
 pwm.enable();                    // Enable the PWM slice
 let led = &mut pwm.channel_b; // Select PWM channel B


### PR DESCRIPTION
Chapter 4.3 accesses PWM slice 6, however, this should be slice 1 for GPIO3. 
This is correct in the [code repo](https://github.com/ImplFerris/pico2-rp-projects/blob/main/ultrasonic/src/main.rs#L47), but seems to be a typo in the book. 

This PR fixes this typo.

Thanks for the wonderful resource!